### PR TITLE
docs: update example CVE ID in API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The server exposes the following tools via the Model Context Protocol:
     -   **Parameters:** `advisory_id` (string) - e.g., "cisco-sa-iosxe-trustsec-bypass-LqL32QG"
 -   `get_cisco_cve_details`
     -   **Description:** Retrieves details for a specific Common Vulnerability and Exposure (CVE) identifier from Cisco.
-    -   **Parameters:** `cve_id` (string) - e.g., "CVE-2023-20078"
+    -   **Parameters:** `cve_id` (string) - e.g., "CVE-2025-20188"
 -   `get_latest_cisco_advisories`
     -   **Description:** Retrieves the most recently published Cisco security advisories.
     -   **Parameters:** `number` (integer, optional, default: 5)


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect changes in the parameters for retrieving Cisco CVE details. Specifically, it modifies the example CVE identifier used in the `get_cisco_cve_details` tool.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73): Updated the example `cve_id` parameter for the `get_cisco_cve_details` tool from "CVE-2023-20078" to "CVE-2025-20188".